### PR TITLE
Fix https://github.com/system76/certification/issues/15

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,13 +1,10 @@
 # Install dependencies, to be moved into debian/control
 set -e
-COSMIC='18.10'
 FIND='deb http:\/\/ppa.launchpad.net\/hardware-certification\/public\/ubuntu cosmic main'
 REPLACE='deb http:\/\/ppa.launchpad.net\/hardware-certification\/public\/ubuntu bionic main'
 
 sudo add-apt-repository -y ppa:hardware-certification/public
-sed -i -e 's/'"$FIND"'/'"$REPLACE"'/g' /etc/apt/sources.list.d/hardware-certification-ubuntu-public-cosmic.list
-
-cat /etc/apt/sources.list.d/hardware-certificaation-ubuntu-public-cosmic.list
+sudo sed -i -e 's/'"$FIND"'/'"$REPLACE"'/g' /etc/apt/sources.list.d/hardware-certification-ubuntu-public-cosmic.list
 
 sudo apt update -y
 sudo apt install -y \

--- a/deps.sh
+++ b/deps.sh
@@ -1,7 +1,14 @@
 # Install dependencies, to be moved into debian/control
 set -e
+COSMIC='18.10'
+FIND='deb http:\/\/ppa.launchpad.net\/hardware-certification\/public\/ubuntu cosmic main'
+REPLACE='deb http:\/\/ppa.launchpad.net\/hardware-certification\/public\/ubuntu bionic main'
 
 sudo add-apt-repository -y ppa:hardware-certification/public
+sed -i -e 's/'"$FIND"'/'"$REPLACE"'/g' /etc/apt/sources.list.d/hardware-certification-ubuntu-public-cosmic.list
+
+cat /etc/apt/sources.list.d/hardware-certificaation-ubuntu-public-cosmic.list
+
 sudo apt update -y
 sudo apt install -y \
     checkbox-ng \


### PR DESCRIPTION
The cosmic ppa for hardware-certification contains an older version of checkbox-ng which was causing the certification suite to fail to run. This pr fixes that by using the bionic ppa.

I have tested that this fix works in both Bionic as well as Cosmic.