### PR TITLE
laptop template: Add various SSD models, require testing of each

### DIFF
--- a/laptops/laptop_testing_template.md
+++ b/laptops/laptop_testing_template.md
@@ -120,8 +120,14 @@ Note: display toggle hotkey is in the displays section below.
 
 ## Hardware compatibility
 
-- [ ] System boots and suspends/resumes with SATA drives populated
-- [ ] System boots and suspends/resumes with both the minimum and maximum supported amounts of RAM
+- [ ] RAM
+    - [ ] System boots and suspends/resumes with both the minimum and maximum supported amounts of RAM/DIMMs
+- [ ] Storage
+    - [ ] System boots and suspends/resumes with all possible SATA drives populated
+    - [ ] System boots and suspends/resumes with each of the following drive models (test each one in every possible slot):
+        - [ ] Samsung 970 Evo Plus
+        - [ ] Samsung 980 Pro
+        - [ ] Western Digital Blue SN550
 
 ### Hardware compatibility notes and issues
 

--- a/laptops/laptop_testing_template.md
+++ b/laptops/laptop_testing_template.md
@@ -128,6 +128,8 @@ Note: display toggle hotkey is in the displays section below.
         - [ ] Samsung 970 Evo Plus (PCIe Gen 3)
         - [ ] Samsung 980 Pro (PCIe Gen 4)
         - [ ] Western Digital Blue SN550 (PCIe Gen 3)
+- [ ] TPM
+    - [ ] `/sys/class/tpm/tpm0` directory exists
 
 ### Hardware compatibility notes and issues
 

--- a/laptops/laptop_testing_template.md
+++ b/laptops/laptop_testing_template.md
@@ -125,9 +125,9 @@ Note: display toggle hotkey is in the displays section below.
 - [ ] Storage
     - [ ] System boots and suspends/resumes with all possible SATA drives populated
     - [ ] System boots and suspends/resumes with each of the following drive models (test each one in every possible slot):
-        - [ ] Samsung 970 Evo Plus
-        - [ ] Samsung 980 Pro
-        - [ ] Western Digital Blue SN550
+        - [ ] Samsung 970 Evo Plus (PCIe Gen 3)
+        - [ ] Samsung 980 Pro (PCIe Gen 4)
+        - [ ] Western Digital Blue SN550 (PCIe Gen 3)
 
 ### Hardware compatibility notes and issues
 


### PR DESCRIPTION
In response to https://github.com/system76/firmware-open/issues/282 / https://github.com/system76/coreboot/pull/90, I have continued to consider how we can turn firmware certification testing into more of a guaranteed process for our customers' sake and less "feeling things out" that is prone to missing large issues.

In this case, we published a lemp10 update that had at least two SSD model-specific issues:
- 970 Evo Plus fails to resume, only in Slot 1
- 980 Pro fails to suspend, only in Slot 2

Historically, Samsung drives have been fairly reliable compared to other brands, so because a Samsung 980 Pro was easily available from the lab, that's what most testing was done with (aside from checking a WD SATA drive in the other slot.) However, in this case, the 970 Evo Plus was behaving differently. Even if the 970 Evo Plus had been tested, if it was tested in Slot 2, the issue would not have been caught; similarly, an issue with the 980 Pro [actually was noticed](https://github.com/system76/firmware/pull/349#issuecomment-1007705877), but later stopped occurring, which I can now explain as being related to the slot that it was in.

Unless we are going to label this kind of incident as an acceptable risk (which I think is lower than where our standards should be), testing both of these drive models individually in each slot individually would have been necessary to correctly diagnose and catch both issues. For that reason, I'm proposing that we add a new section to the laptop testing template to test a defined list of SSDs in each slot, including suspend/resume with each one. (I've also added the WD Blue SN550 for good measure, since we have seen it behave strangely with proprietary firmware before.)

Because SSD models may change over time, the only alternative I can think of would be maintaining a list for each model of every SSD that we've shipped, so we only have to test SSDs that have actually been shipped in a model. However, that would not catch aftermarket installations, and doesn't seem like something that we are currently collecting enough data on from the laptop assembly team to be possible.

An important aspect of this change is that every SSD model on the list needs to be available perpetually and readily in the lab to use for testing. I'm open to hearing alternative perspectives on if there are more efficient ways to guarantee functionality.